### PR TITLE
Fixed files not being moved if camera is not brand new

### DIFF
--- a/HERO/LoopVideo/2Min/autoexec.ash
+++ b/HERO/LoopVideo/2Min/autoexec.ash
@@ -1,22 +1,22 @@
 sleep 2
 t app key record
-deletedir d:\DCIM\8minbefore
+deletedir d:\pastloopedrecordings\8minbefore
 mkdir d:\DCIM\8minbefore
-mv d:\DCIM\6minbefore\* d:\DCIM\8minbefore\
+mv d:\pastloopedrecordings\6minbefore\* d:\pastloopedrecordings\8minbefore\
 sleep 5
-deletedir d:\DCIM\6minbefore
-mkdir d:\DCIM\6minbefore
-mv d:\DCIM\4minbefore\* d:\DCIM\6minbefore\
+deletedir d:\pastloopedrecordings\6minbefore
+mkdir d:\pastloopedrecordings\6minbefore
+mv d:\pastloopedrecordings\4minbefore\* d:\pastloopedrecordings\6minbefore\
 sleep 5
-deletedir d:\DCIM\4minbefore
-mkdir d:\DCIM\4minbefore
-mv d:\DCIM\2minbefore\* d:\DCIM\4minbefore\
+deletedir d:\pastloopedrecordings\4minbefore
+mkdir d:\pastloopedrecordings\4minbefore
+mv d:\pastloopedrecordings\2minbefore\* d:\pastloopedrecordings\4minbefore\
 sleep 5
-deletedir d:\DCIM\2minbefore
-mkdir d:\DCIM\2minbefore
+deletedir d:\pastloopedrecordings\2minbefore
+mkdir d:\pastloopedrecordings\2minbefore
 sleep 105
 t app key record
 sleep 1
-mv d:\DCIM\100GOPRO\* d:\DCIM\2minbefore\
+mv d:\DCIM\* d:\pastloopedrecordings\2minbefore\
 sleep 5
 reboot yes

--- a/HERO/LoopVideo/2Min/autoexec.ash
+++ b/HERO/LoopVideo/2Min/autoexec.ash
@@ -1,7 +1,7 @@
 sleep 2
 t app key record
 deletedir d:\pastloopedrecordings\8minbefore
-mkdir d:\DCIM\8minbefore
+mkdir d:\pastloopedrecordings\8minbefore
 mv d:\pastloopedrecordings\6minbefore\* d:\pastloopedrecordings\8minbefore\
 sleep 5
 deletedir d:\pastloopedrecordings\6minbefore

--- a/HERO/LoopVideo/Readme.md
+++ b/HERO/LoopVideo/Readme.md
@@ -2,11 +2,11 @@
 
 Whether you want to use it as a dash cam to film some russian adventures or record the longest ski run, this hack will allow you to use the feature only found in the HERO3Black/HERO3+Black/HERO4 directly in your 129$ GoPro HERO.
 
-Choose the duration you want, click a folder, click autoexec.ash, right click on RAW, choose SAVE AS, save as in the root of the SD card where DCIM and MISC are. Turn it on and it acts like in Quick Capture, it will start recording looping videos. Perfect for Dash cam.
+Choose the duration you want, click a folder, click autoexec.ash, right click on RAW, choose SAVE AS, save as in the root of the SD card where DCIM and MISC are. Turn it on and it acts like in Quick Capture, it will start recording looping videos. Perfect for Dash cam. *The SD card must be empty of footage before using this hack, or else any footage already on the SD card will be deleted!*
 
 SimpleLoop will do the simplest of functionality. Record, delete, repeat. Make sure you get to your recorded file and turn off your GoPro before that second part, or else your totally-only-took-one-try triple trampoline flip will be lost forever.
 
-With the new functionality in the more advanced versions (work in progress, or maybe I should say "totally broken"), the previous clips will be stored in appropriate folders in DCIM.
+With the new functionality in the more advanced versions, the previous clips will be stored in appropriate folders on the root of the SD card. 
   * For the two minute script, up to 5 clips are saved in the "loop"
   * For the five minute script, up to 3 clips are saved in the "loop"
   * For the ten minute script, up to 2 clips are saved in the "loop"

--- a/HERO/LoopVideo/Readme.md
+++ b/HERO/LoopVideo/Readme.md
@@ -2,7 +2,7 @@
 
 Whether you want to use it as a dash cam to film some russian adventures or record the longest ski run, this hack will allow you to use the feature only found in the HERO3Black/HERO3+Black/HERO4 directly in your 129$ GoPro HERO.
 
-Choose the duration you want, click a folder, click autoexec.ash, right click on RAW, choose SAVE AS, save as in the root of the SD card where DCIM and MISC are. Turn it on and it acts like in Quick Capture, it will start recording looping videos. Perfect for Dash cam. *The SD card must be empty of footage before using this hack, or else any footage already on the SD card will be deleted!*
+Choose the duration you want, click a folder, click autoexec.ash, right click on RAW, choose SAVE AS, save as in the root of the SD card where DCIM and MISC are. Turn it on and it acts like in Quick Capture, it will start recording looping videos. Perfect for Dash cam. *The SD card must be empty of footage before using this hack, or else any footage already on the SD card may be deleted!*
 
 SimpleLoop will do the simplest of functionality. Record, delete, repeat. Make sure you get to your recorded file and turn off your GoPro before that second part, or else your totally-only-took-one-try triple trampoline flip will be lost forever.
 


### PR DESCRIPTION
Fixed an issue where files weren't being moved if the recording folder was named something different (common if the camera has been used before). Past recordings are now saved in their own folder on root of SD card instead of /DCIM/ as a result.
